### PR TITLE
Problem: The subfolder paths are derived from the title name from SUMMARY.md

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ module.exports = {
         if (page.title.match(/^\d+\/.+/) !== null) {
           // save a spec: copy
           var n = page.title.split('/')[0]
-          var name = page.title.split('/')[1]
+          var name = shortnames[n].split('/')[1]
           try {
             fs.mkdirSync("_book/" + name);
           } catch (e) {


### PR DESCRIPTION
when i have a RFC:
- name: "Full Name"
- shortname "1/FN" 
- link in the SUMMARY.md: "1/FN: Full Name"

then the subfolder gets created like: "_book/spec:1/FN: Full Name" and so on... Alle the links to this RFC are set like this: "../../spec:1/FN/" .. so for references shortnames are used while for creation the label name of the sidebar (SUMMARY.md) is used...

This PR fixes that by using the shortname